### PR TITLE
feat: Add tag validation for Techleads.club pillars

### DIFF
--- a/cmd/generate_readme/main.go
+++ b/cmd/generate_readme/main.go
@@ -178,15 +178,15 @@ func GenerateREADME(items []catalog.CatalogItem) (string, error) {
 	})
 
 	technicalExcellence := formatCatalogItems(filterItem(items, func(item catalog.CatalogItem) bool {
-		return hasTag(item, "Excelência Técnica")
+		return hasTag(item, catalog.TechnicalExcellenceTag)
 	}))
 
 	leadershipAndInspiration := formatCatalogItems(filterItem(items, func(item catalog.CatalogItem) bool {
-		return hasTag(item, "Liderança e Inspiração")
+		return hasTag(item, catalog.LeadershipAndInspirationTag)
 	}))
 
 	deliveringValue := formatCatalogItems(filterItem(items, func(item catalog.CatalogItem) bool {
-		return hasTag(item, "Entrega de Valor")
+		return hasTag(item, catalog.DeliveringValueTag)
 	}))
 
 	const readmeTemplate = `

--- a/internal/catalog.go
+++ b/internal/catalog.go
@@ -6,6 +6,12 @@ import (
 	"gopkg.in/yaml.v3"
 )
 
+const (
+        TechnicalExcellenceTag      = "Excelência Técnica"
+        LeadershipAndInspirationTag = "Liderança e Inspiração"
+        DeliveringValueTag          = "Entrega de Valor"
+)
+
 type CatalogItem struct {
 	URL         string   `yaml:"url"`
 	Title       string   `yaml:"title"`
@@ -56,5 +62,18 @@ func validateCatalogItem(item CatalogItem) error {
 		return fmt.Errorf("tags cannot be empty")
 	}
 
-	return nil
+	pillarTags := map[string]bool{
+		TechnicalExcellenceTag:      true,
+		LeadershipAndInspirationTag: true,
+		DeliveringValueTag:          true,
+	}
+
+	for _, tag := range item.Tags {
+		if pillarTags[tag] {
+			return nil
+		}
+	}
+
+	return fmt.Errorf("item must have at least one pillar tag: %s, %s, or %s", 
+		TechnicalExcellenceTag, LeadershipAndInspirationTag, DeliveringValueTag)
 }


### PR DESCRIPTION
## Fazer a validação das tags com os pilares da comunidade

### Antes e Depois  
| Antes                       | Depois                        |
|------------------------------|------------------------------|
| *O README era gerado sem validar se os itens tinham tags correspondentes aos pilares da comunidade, podendo resultar na omissão de conteúdos sem pilar definido.* | *Agora, ao gerar o README, a validação garante que os itens possuem ao menos uma tag correspondente a um dos pilares, evitando a omissão de conteúdos.* |

<!-- Link References -->
[before-image]: https://github.com/link-to-before-screenshot
[after-image]: https://github.com/link-to-after-screenshot

---

### Changes  
Este PR implementa a validação das tags dos itens do catálogo para garantir que cada item esteja associado a pelo menos um dos pilares da comunidade antes de ser exibido no README.  
As principais mudanças incluem:  

- Adicionada validação de tags obrigatórias na função `validateCatalogItem` dentro de `internal/catalog.go`.
- Criadas constantes para os pilares na implementação do gerador de README em `cmd/generate_readme/main.go`.
- Refatoração para melhorar a organização da lógica de validação das tags.

---

### Como testar?  
1. Gere o README localmente usando `go run cmd/generate_readme/main.go`.
2. Verifique se os itens sem um pilar definido não são exibidos no arquivo gerado.
3. Adicione/remova tags dos itens no catálogo e observe se a validação funciona corretamente.

🔗 **Commit:** [75f77b1](https://github.com/tech-leads-club/awesome-tech-lead/pull/9/commits/75f77b17a45849ee9255dc26c27dd3c41ab7d9a8)  
