### PR TITLE
feat: Adiciona validação nas bandas de carreira

### DIFF
--- a/catalog.yml
+++ b/catalog.yml
@@ -1872,6 +1872,11 @@ catalog:
         - Qualidade
       is_paid: false
       level: advanced
+      career_bands:
+        - senior
+        - tl
+        - staff
+        - principal
       language: en_us
     - url: https://www.trinitytakei.io/blog/17-traits-of-awesome-tech-leads
       title: 17 Traits of Awesome Tech Leads


### PR DESCRIPTION
Esse PR adiciona validação nas bandas de carreira para garantir que todo item tenha uma banda e que elas façam parte de uma lista de enums.

Além disso, refatora a validação do item do catálogo para coletar todos os erros e, em caso de falha, mostrar o título do item e todos os erros.

```
error parsing catalog: validation error for item "Looks good to me is a lazy default - Why managers should give feedback on work output": validation errors: career bands cannot be empty
```